### PR TITLE
Increase WP timeout (#6)

### DIFF
--- a/class-zasilkovna.php
+++ b/class-zasilkovna.php
@@ -206,7 +206,11 @@ class WC_Zasilkovna_Shipping_Method extends WC_Shipping_Method {
 
     function fetch_pickup_points( $api_key ) {
         $url = 'https://www.zasilkovna.cz/api/v3/' . $api_key . '/branch.json';
-        $result = wp_remote_get( $url );
+        $result = wp_remote_get( $url,
+            array(
+                'timeout'     => 60,
+            )
+        );
         if ( is_wp_error( $result ) ) {
             throw new Exception( __METHOD__ . ": failed to get content from {$url}." );
         }


### PR DESCRIPTION
Standard WP timeout is 5s which is not enough for downloading Zásilkovna's JSON if you have an averagely slow connection.
Solves issue #6.